### PR TITLE
feat(rpc): add endpoint `be_getLatestBlockNumber`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,5 +56,8 @@ Templates for Unreleased:
 
 ## Unreleased
 
+#### Features
+- (rpc) [#2](https://github.com/bcdevtools/block-explorer-rpc-cosmos/pull/2) Add endpoint `be_getLatestBlockNumber`
+
 #### Improvements
 - (parser) [#1](https://github.com/bcdevtools/block-explorer-rpc-cosmos/pull/1) Add message signer into involvers list

--- a/be_rpc/backend/backend.go
+++ b/be_rpc/backend/backend.go
@@ -28,6 +28,9 @@ type BackendI interface {
 
 	// Block
 
+	// GetLatestBlockNumber returns the latest block number, along with the epoch UTC seconds.
+	GetLatestBlockNumber() (berpctypes.GenericBackendResponse, error)
+
 	// GetBlockByNumber returns a block by its height.
 	GetBlockByNumber(height int64) (berpctypes.GenericBackendResponse, error)
 

--- a/be_rpc/backend/block.go
+++ b/be_rpc/backend/block.go
@@ -11,6 +11,18 @@ import (
 	"strings"
 )
 
+func (m *Backend) GetLatestBlockNumber() (berpctypes.GenericBackendResponse, error) {
+	statusInfo, err := m.clientCtx.Client.Status(m.ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	return berpctypes.GenericBackendResponse{
+		"latestBlock":             statusInfo.SyncInfo.LatestBlockHeight,
+		"latestBlockTimeEpochUTC": statusInfo.SyncInfo.LatestBlockTime.UTC().Unix(),
+	}, nil
+}
+
 func (m *Backend) GetBlockByNumber(height int64) (berpctypes.GenericBackendResponse, error) {
 	resBlock, err := m.queryClient.ServiceClient.GetBlockWithTxs(m.ctx, &tx.GetBlockWithTxsRequest{
 		Height: height,

--- a/be_rpc/namespaces/be/block.go
+++ b/be_rpc/namespaces/be/block.go
@@ -2,6 +2,11 @@ package be
 
 import berpctypes "github.com/bcdevtools/block-explorer-rpc-cosmos/be_rpc/types"
 
+func (api *API) GetLatestBlockNumber() (berpctypes.GenericBackendResponse, error) {
+	api.logger.Debug("be_getLatestBlockNumber")
+	return api.backend.GetLatestBlockNumber()
+}
+
 func (api *API) GetBlockByNumber(height int64) (berpctypes.GenericBackendResponse, error) {
 	api.logger.Debug("be_getBlockByNumber")
 	return api.backend.GetBlockByNumber(height)

--- a/be_rpc/utils/address.go
+++ b/be_rpc/utils/address.go
@@ -1,7 +1,33 @@
 package utils
 
-import "strings"
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	"strings"
+)
 
 func NormalizeAddress(address string) string {
 	return strings.ToLower(strings.TrimSpace(address))
+}
+
+// IsZeroAccAddress returns true if the address is 0x00..00
+func IsZeroAccAddress(accAddr sdk.AccAddress) bool {
+	for _, b := range accAddr.Bytes() {
+		if b != 0x00 {
+			return false
+		}
+	}
+
+	return true
+}
+
+// IsZeroEvmAddress returns true if the address is 0x00..00
+func IsZeroEvmAddress(addr common.Address) bool {
+	for _, b := range addr.Bytes() {
+		if b != 0x00 {
+			return false
+		}
+	}
+
+	return true
 }

--- a/be_rpc/utils/address_test.go
+++ b/be_rpc/utils/address_test.go
@@ -1,0 +1,17 @@
+package utils
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestIsZeroAddress(t *testing.T) {
+	addr1 := common.HexToAddress("0x0000000000000000000000000000000000000000")
+	require.True(t, IsZeroEvmAddress(addr1))
+	require.True(t, IsZeroAccAddress(addr1.Bytes()))
+
+	addr2 := common.HexToAddress("0x0000000000000000000000000000000000000001")
+	require.False(t, IsZeroEvmAddress(addr2))
+	require.False(t, IsZeroAccAddress(addr2.Bytes()))
+}


### PR DESCRIPTION
For performance reason, a frequently needed info is latest block number will be extracted into a dedicated RPC endpoint.